### PR TITLE
Update entrypoint.sh

### DIFF
--- a/manual_build/entrypoint.sh
+++ b/manual_build/entrypoint.sh
@@ -2,7 +2,7 @@
 
 downloadsPath="/downloads"
 profilePath="/config"
-qbtConfigFile="$profilePath/qBittorrent/config/qBittorrent.conf"
+qbtConfigFile="$profilePath/config/qBittorrent.conf"
 
 if [ -n "$PUID" ]; then
     sed -i "s|^qbtUser:x:[0-9]*:|qbtUser:x:$PUID:|g" /etc/passwd


### PR DESCRIPTION
Because users always define a path for apps, like /docker/qBit/.

All other Docker compose works like this.