### PR TITLE
Allow rootless containers

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,13 +55,18 @@ if [ -z "$QBT_WEBUI_PORT" ]; then
     QBT_WEBUI_PORT=8080
 fi
 
-# those are owned by root by default
-# don't change existing files owner in `$downloadsPath`
-if [ -d "$downloadsPath" ]; then
-    chown qbtUser:qbtUser "$downloadsPath"
-fi
-if [ -d "$profilePath" ]; then
-    chown qbtUser:qbtUser -R "$profilePath"
+if [ -d "$ROOTLESS" ] && [ "$ROOTLESS" == "true" ]; then
+    finalUser="root"
+else
+    finalUser="qbtUser"
+    # those are owned by root by default
+    # don't change existing files owner in `$downloadsPath`
+    if [ -d "$downloadsPath" ]; then
+        chown qbtUser:qbtUser "$downloadsPath"
+    fi
+    if [ -d "$profilePath" ]; then
+        chown qbtUser:qbtUser -R "$profilePath"
+    fi
 fi
 
 # set umask just before starting qbt
@@ -70,8 +75,8 @@ if [ -n "$UMASK" ]; then
 fi
 
 exec \
-    doas -u qbtUser \
-        qbittorrent-nox \
-            --profile="$profilePath" \
-            --webui-port="$QBT_WEBUI_PORT" \
-            "$@"
+    doas -u $finalUser \
+    qbittorrent-nox \
+    --profile="$profilePath" \
+    --webui-port="$QBT_WEBUI_PORT" \
+    "$@"


### PR DESCRIPTION
When the ROOTLESS env variable is set, this allows qbitorrent to run  as root instead of qbituser.  

For rootfull containers we wish to stay with qbituser, so the default behaviour don't change. 

With rootless containers root id in the container equals user id in the host, while another user in the container is seen as 10000+ id on the host. This is easier for volumes permissions management. 