### PR TITLE
Support Docker image running rootless

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,10 +66,19 @@ if [ -n "$UMASK" ]; then
     umask "$UMASK"
 fi
 
-exec \
-    doas -u qbtUser \
+if [ "$(id -u)" -eq 0 ]; then
+    exec \
+        doas -u qbtUser \
+            qbittorrent-nox \
+                "$confirmLegalNotice" \
+                --profile="$profilePath" \
+                --webui-port="$QBT_WEBUI_PORT" \
+                "$@"
+else
+    exec \
         qbittorrent-nox \
             "$confirmLegalNotice" \
             --profile="$profilePath" \
             --webui-port="$QBT_WEBUI_PORT" \
             "$@"
+fi


### PR DESCRIPTION
I run all my Docker images rootless and unfortunately the binary `doas` requires running as root. I understand why you are using it, as the vast majority of people run Docker images as root and dropping to an unprivileged user when running the actual binary is a good idea. But for people who are already running rootless, `doas` becomes a problem instead of a solution.

The solution to satisfy both parties is to only use `doas` when running as root. If not root, then run the binary directly.