### PR TITLE
Removed the top-level version element

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   qbittorrent-nox:
     # for debugging


### PR DESCRIPTION
According to the [compose file reference](https://github.com/docker/docs/blob/6c8c8f874b0234b65b8f678d397ab694b929ef80/content/reference/compose-file/version-and-name.md), the top-level version property is obsolete and will result in warnings when used