### PR TITLE
Add support for resolving interface from ip at startup

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,6 +64,10 @@ https://github.com/qbittorrent/qBittorrent/issues
     * `QBT_WEBUI_PORT` \
       This environment variable defines the port number used for qBittorrent WebUI.
       Defaults to port `8080` if value is not set.
+    * `QBT_INTERFACE_IP` \
+      This environment variable defines the ip address of the interface you wish
+      to bind qbitorrent to. This is helpful if you know your container's ip address
+      at startup. Defaults to blank.
 
     #### Volumes
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,7 @@ if [ ! -f "$qbtConfigFile" ]; then
     cat << EOF > "$qbtConfigFile"
 [BitTorrent]
 Session\DefaultSavePath=$downloadsPath
+Session\Interface=lo
 Session\Port=6881
 Session\TempPath=$downloadsPath/temp
 Session\TempPathEnabled=true
@@ -44,6 +45,12 @@ MigrationVersion=9999
 [Preferences]
 WebUI\Port=8080
 EOF
+fi
+
+# Run each time as the interface can change in a container
+if [ -n "$QBT_INTERFACE_IP" ]; then
+    QBT_INTERFACE=$(ip -o addr show | awk -v ip="${QBT_INTERFACE_IP}" '{split($4, a, "/"); if (a[1] == ip) print $2}')
+    sed -i "s|^Session\\\\Interface=.*|Session\\\\Interface=${QBT_INTERFACE}|g" "$qbtConfigFile"
 fi
 
 argLegalNotice=""


### PR DESCRIPTION
This assigns the proper interface based on the supplied ip address. This is helpful when using static networking as you know where the traffic needs to go and prevents having to update the config after a restart.